### PR TITLE
[Bug Fixed while deployment]--Update react-scripts to version 5.0.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7461,7 +7461,7 @@ react-router@6.2.1:
 
 react-scripts@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-5.0.1.tgz#6285dbd65a8ba6e49ca8d651ce30645a6d980003"
   integrity sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==
   dependencies:
     "@babel/core" "^7.16.0"


### PR DESCRIPTION
Resolved deployment issues on Vercel by updating react scripts and adjusting the `yarn.lock` file to reflect the changes.

### previous error:
![2024-10-26 (1)](https://github.com/user-attachments/assets/79270d7b-2672-4904-965f-8363a9078ce1)
